### PR TITLE
Refactoring

### DIFF
--- a/execution.go
+++ b/execution.go
@@ -37,7 +37,8 @@ func (g *GWBProgram) Execute(ctx context.Context) (GWBResult, error) {
 		ctx,
 		http.MethodPost,
 		WandBoxUrl+"compile.json",
-		bytes.NewBuffer(data))
+		bytes.NewBuffer(data),
+	)
 
 	if err != nil {
 		return result, err
@@ -46,6 +47,10 @@ func (g *GWBProgram) Execute(ctx context.Context) (GWBResult, error) {
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := client.Do(req)
+
+	if err != nil {
+		return result, err
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		defer resp.Body.Close()

--- a/execution.go
+++ b/execution.go
@@ -2,25 +2,16 @@ package gowandbox
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io/ioutil"
 	"net/http"
-	"time"
 )
 
-// Returns new GWBProgram struct, after filling it out with defaults
-func NewGWBProgram() GWBProgram {
-	return GWBProgram{
-		Compiler:          "",
-		Code:              "",
-		Codes:             []Program{},
-		Options:           "",
-		CompilerOptionRaw: "",
-		RuntimeOptionRaw:  "",
-		Stdin:             "",
-		SaveCode:          false,
-	}
+func NewGWBProgram() *GWBProgram {
+	// Returns new GWBProgram struct
+	return &GWBProgram{}
 }
 
 /*
@@ -31,7 +22,7 @@ If the response code is not 200, an error is returned.
 
 Maps to the `/compile.json` endpoint
 */
-func (g *GWBProgram) Execute(timeout int) (GWBResult, error) {
+func (g *GWBProgram) Execute(ctx context.Context) (GWBResult, error) {
 
 	data, err := json.Marshal(g)
 	var result GWBResult
@@ -40,19 +31,21 @@ func (g *GWBProgram) Execute(timeout int) (GWBResult, error) {
 		return result, err
 	}
 
-	client := http.Client{
-		Timeout: time.Duration(timeout) * time.Millisecond,
-	}
+	client := http.DefaultClient
 
-	resp, err := client.Post(
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
 		WandBoxUrl+"compile.json",
-		"application/json",
-		bytes.NewBuffer(data),
-	)
+		bytes.NewBuffer(data))
 
 	if err != nil {
 		return result, err
 	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
 
 	if resp.StatusCode != http.StatusOK {
 		defer resp.Body.Close()

--- a/execution_test.go
+++ b/execution_test.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"strings"
 	"testing"
-	// "time"
+	"time"
 )
 
 func assert(expected, got string, t *testing.T) {
@@ -45,35 +45,35 @@ func TestExecution(t *testing.T) {
 	assert("", result.CompilerOutput, t)
 }
 
-// func TestExecutionTimeout(t *testing.T) {
-//
-// 	prog := NewGWBProgram()
-//
-// 	prog.Code = "import gwbutil\n\ngwbutil.say()"
-// 	prog.Codes = []Program{
-// 		{
-// 			"gwbutil.py",
-// 			"def say(): print(input())",
-// 		},
-// 	}
-// 	prog.Options = "warning"
-// 	prog.Compiler = "cpython-3.8.0"
-// 	prog.Stdin = "123"
-//
-// 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-// 	cancel()
-//
-// 	_, err := prog.Execute(ctx)
-//
-// 	if ctx.Err() == nil {
-// 		t.Error("Got no error, but was expecting one!")
-// 	}
-// 	if !strings.Contains(err.Error(), "context deadline exceeded") {
-// 		t.Error(err.Error())
-// 	}
-//
-// 	t.Log("Request timed out, as expected")
-// }
+func TestExecutionTimeout(t *testing.T) {
+
+	prog := NewGWBProgram()
+
+	prog.Code = "import gwbutil\n\ngwbutil.say()"
+	prog.Codes = []Program{
+		{
+			"gwbutil.py",
+			"def say(): print(input())",
+		},
+	}
+	prog.Options = "warning"
+	prog.Compiler = "cpython-3.8.0"
+	prog.Stdin = "123"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+
+	_, err := prog.Execute(ctx)
+
+	if err == nil {
+		t.Error("Got no error, but was expecting one!")
+	}
+	if !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Error(err.Error())
+	}
+
+	t.Log("Request timed out, as expected")
+}
 
 func TestExecutionBadCompiler(t *testing.T) {
 

--- a/execution_test.go
+++ b/execution_test.go
@@ -1,9 +1,11 @@
 package gowandbox
 
 import (
+	"context"
 	"log"
 	"strings"
 	"testing"
+	// "time"
 )
 
 func assert(expected, got string, t *testing.T) {
@@ -27,7 +29,7 @@ func TestExecution(t *testing.T) {
 	prog.Compiler = "cpython-3.8.0"
 	prog.Stdin = "123\n456"
 
-	result, err := prog.Execute(10000)
+	result, err := prog.Execute(context.Background())
 
 	if err != nil {
 		t.Error(err.Error())
@@ -43,33 +45,35 @@ func TestExecution(t *testing.T) {
 	assert("", result.CompilerOutput, t)
 }
 
-func TestExecutionTimeout(t *testing.T) {
-
-	prog := NewGWBProgram()
-
-	prog.Code = "import gwbutil\n\ngwbutil.say()"
-	prog.Codes = []Program{
-		{
-			"gwbutil.py",
-			"def say(): print(input())",
-		},
-	}
-	prog.Options = "warning"
-	prog.Compiler = "cpython-3.8.0"
-	prog.Stdin = "123"
-
-	_, err := prog.Execute(1)
-
-	if err == nil {
-		t.Error("Got no error, but was expecting one!")
-	}
-
-	if !strings.Contains(err.Error(), "context deadline exceeded") {
-		t.Error(err.Error())
-	}
-
-	t.Log("Request timed out, as expected")
-}
+// func TestExecutionTimeout(t *testing.T) {
+//
+// 	prog := NewGWBProgram()
+//
+// 	prog.Code = "import gwbutil\n\ngwbutil.say()"
+// 	prog.Codes = []Program{
+// 		{
+// 			"gwbutil.py",
+// 			"def say(): print(input())",
+// 		},
+// 	}
+// 	prog.Options = "warning"
+// 	prog.Compiler = "cpython-3.8.0"
+// 	prog.Stdin = "123"
+//
+// 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+// 	cancel()
+//
+// 	_, err := prog.Execute(ctx)
+//
+// 	if ctx.Err() == nil {
+// 		t.Error("Got no error, but was expecting one!")
+// 	}
+// 	if !strings.Contains(err.Error(), "context deadline exceeded") {
+// 		t.Error(err.Error())
+// 	}
+//
+// 	t.Log("Request timed out, as expected")
+// }
 
 func TestExecutionBadCompiler(t *testing.T) {
 
@@ -86,7 +90,7 @@ func TestExecutionBadCompiler(t *testing.T) {
 	prog.Compiler = "abc"
 	prog.Stdin = "123"
 
-	_, err := prog.Execute(10000)
+	_, err := prog.Execute(context.Background())
 
 	if err == nil {
 		t.Error("Got no error, but was expecting one!")

--- a/get_languages.go
+++ b/get_languages.go
@@ -1,26 +1,33 @@
 package gowandbox
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io/ioutil"
 	"net/http"
-	"time"
 )
 
 /*
 Returns a list of languages, maps to the `/list.json` endpoint
 */
-func GetLanguages(timeout int) ([]GWBLanguage, error) {
+func GetLanguages(ctx context.Context) ([]GWBLanguage, error) {
 	var result []GWBLanguage
 
-	client := http.Client{
-		Timeout: time.Duration(timeout) * time.Millisecond,
+	client := http.DefaultClient
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		WandBoxUrl+"list.json",
+		nil,
+	)
+
+	if err != nil {
+		return result, err
 	}
 
-	resp, err := client.Get(
-		WandBoxUrl + "list.json",
-	)
+	resp, err := client.Do(req)
 
 	if err != nil {
 		return result, err

--- a/get_languages_test.go
+++ b/get_languages_test.go
@@ -1,12 +1,12 @@
 package gowandbox
 
 import (
-	"strings"
+	"context"
 	"testing"
 )
 
 func TestGetLanguages(t *testing.T) {
-	result, err := GetLanguages(10000)
+	result, err := GetLanguages(context.Background())
 
 	if err != nil {
 		t.Error(err.Error())
@@ -15,16 +15,16 @@ func TestGetLanguages(t *testing.T) {
 	}
 }
 
-func TestGetLanguagesTimeoutError(t *testing.T) {
-	_, err := GetLanguages(1)
-
-	if err == nil {
-		t.Error("Got no error, but was expecting one!")
-	}
-
-	if !strings.Contains(err.Error(), "context deadline exceeded") {
-		t.Fatal(err.Error())
-	}
-
-	t.Log("Request timed out, as expected")
-}
+// func TestGetLanguagesTimeoutError(t *testing.T) {
+// 	_, err := GetLanguages(1)
+//
+// 	if err == nil {
+// 		t.Error("Got no error, but was expecting one!")
+// 	}
+//
+// 	if !strings.Contains(err.Error(), "context deadline exceeded") {
+// 		t.Fatal(err.Error())
+// 	}
+//
+// 	t.Log("Request timed out, as expected")
+// }

--- a/get_languages_test.go
+++ b/get_languages_test.go
@@ -2,7 +2,9 @@ package gowandbox
 
 import (
 	"context"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestGetLanguages(t *testing.T) {
@@ -15,16 +17,21 @@ func TestGetLanguages(t *testing.T) {
 	}
 }
 
-// func TestGetLanguagesTimeoutError(t *testing.T) {
-// 	_, err := GetLanguages(1)
-//
-// 	if err == nil {
-// 		t.Error("Got no error, but was expecting one!")
-// 	}
-//
-// 	if !strings.Contains(err.Error(), "context deadline exceeded") {
-// 		t.Fatal(err.Error())
-// 	}
-//
-// 	t.Log("Request timed out, as expected")
-// }
+func TestGetLanguagesTimeoutError(t *testing.T) {
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+
+	defer cancel()
+
+	_, err := GetLanguages(ctx)
+
+	if err == nil {
+		t.Error("Got no error, but was expecting one!")
+	}
+
+	if !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Fatal(err.Error())
+	}
+
+	t.Log("Request timed out, as expected")
+}

--- a/get_template.go
+++ b/get_template.go
@@ -1,11 +1,11 @@
 package gowandbox
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io/ioutil"
 	"net/http"
-	"time"
 )
 
 /*
@@ -13,17 +13,24 @@ import (
 	If the language is not found, an error is returned (bad template).
 	Maps to the `/template/:template` endpoint
 */
-func GetTemplate(language string, timeout int) (GWBTemplate, error) {
+func GetTemplate(language string, ctx context.Context) (GWBTemplate, error) {
 
-	client := http.Client{
-		Timeout: time.Duration(timeout) * time.Millisecond,
-	}
+	client := http.DefaultClient
 
 	templ := GWBTemplate{}
 
-	resp, err := client.Get(
-		WandBoxUrl + "template/" + language,
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		WandBoxUrl+"template/"+language,
+		nil,
 	)
+
+	if err != nil {
+		return templ, err
+	}
+
+	resp, err := client.Do(req)
 
 	if err != nil {
 		return templ, err

--- a/get_template_test.go
+++ b/get_template_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestTemplate(t *testing.T) {
@@ -30,16 +31,21 @@ func TestBadTemplateError(t *testing.T) {
 	t.Log("Template for `abc` was not found, as expected")
 }
 
-// func TestTemplateTimeoutError(t *testing.T) {
-// 	_, err := GetTemplate("", 1)
-//
-// 	if err == nil {
-// 		t.Error("Got no error, but was expecting one!")
-// 	}
-//
-// 	if !strings.Contains(err.Error(), "context deadline exceeded") {
-// 		t.Error(err.Error())
-// 	}
-//
-// 	t.Log("Request timed out as expected")
-// }
+func TestTemplateTimeoutError(t *testing.T) {
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+
+	defer cancel()
+
+	_, err := GetTemplate("", ctx)
+
+	if err == nil {
+		t.Error("Got no error, but was expecting one!")
+	}
+
+	if !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Error(err.Error())
+	}
+
+	t.Log("Request timed out as expected")
+}

--- a/get_template_test.go
+++ b/get_template_test.go
@@ -1,12 +1,13 @@
 package gowandbox
 
 import (
+	"context"
 	"strings"
 	"testing"
 )
 
 func TestTemplate(t *testing.T) {
-	template, err := GetTemplate("cpython", 10000)
+	template, err := GetTemplate("cpython", context.Background())
 
 	if err != nil {
 		t.Error(err.Error())
@@ -16,7 +17,7 @@ func TestTemplate(t *testing.T) {
 }
 
 func TestBadTemplateError(t *testing.T) {
-	_, err := GetTemplate("abc", 10000)
+	_, err := GetTemplate("abc", context.Background())
 
 	if err == nil {
 		t.Error("Got no error, but was expecting one!")
@@ -29,16 +30,16 @@ func TestBadTemplateError(t *testing.T) {
 	t.Log("Template for `abc` was not found, as expected")
 }
 
-func TestTemplateTimeoutError(t *testing.T) {
-	_, err := GetTemplate("", 1)
-
-	if err == nil {
-		t.Error("Got no error, but was expecting one!")
-	}
-
-	if !strings.Contains(err.Error(), "context deadline exceeded") {
-		t.Error(err.Error())
-	}
-
-	t.Log("Request timed out as expected")
-}
+// func TestTemplateTimeoutError(t *testing.T) {
+// 	_, err := GetTemplate("", 1)
+//
+// 	if err == nil {
+// 		t.Error("Got no error, but was expecting one!")
+// 	}
+//
+// 	if !strings.Contains(err.Error(), "context deadline exceeded") {
+// 		t.Error(err.Error())
+// 	}
+//
+// 	t.Log("Request timed out as expected")
+// }

--- a/get_user.go
+++ b/get_user.go
@@ -1,11 +1,11 @@
 package gowandbox
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io/ioutil"
 	"net/http"
-	"time"
 )
 
 /*
@@ -13,16 +13,23 @@ import (
 	If the session key is invalid, a blank string is returned for the username.
 	Maps to the `/user.json` endpoint.
 */
-func GetUser(sessionKey string, timeout int) (GWBUser, error) {
+func GetUser(sessionKey string, ctx context.Context) (GWBUser, error) {
 	var result GWBUser
 
-	client := http.Client{
-		Timeout: time.Duration(timeout) * time.Millisecond,
+	client := http.DefaultClient
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		WandBoxUrl+"/user.json?session="+sessionKey,
+		nil,
+	)
+
+	if err != nil {
+		return result, err
 	}
 
-	resp, err := client.Get(
-		WandBoxUrl + "/user.json?session=" + sessionKey,
-	)
+	resp, err := client.Do(req)
 
 	if err != nil {
 		return result, err

--- a/get_user_test.go
+++ b/get_user_test.go
@@ -1,12 +1,12 @@
 package gowandbox
 
 import (
-	"strings"
+	"context"
 	"testing"
 )
 
 func TestUserNotFoundError(t *testing.T) {
-	user, err := GetUser("", 10000) // Dummy string
+	user, err := GetUser("", context.Background()) // Dummy string
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -18,16 +18,16 @@ func TestUserNotFoundError(t *testing.T) {
 	t.Log("User was not found, as expected")
 }
 
-func TestUserTimeoutError(t *testing.T) {
-	_, err := GetUser("", 1)
-
-	if err == nil {
-		t.Error("Got no error, but was expecting one!")
-	}
-
-	if !strings.Contains(err.Error(), "context deadline exceeded") {
-		t.Error(err.Error())
-	}
-
-	t.Log("Request timed out as expected")
-}
+// func TestUserTimeoutError(t *testing.T) {
+// 	_, err := GetUser("", 1)
+//
+// 	if err == nil {
+// 		t.Error("Got no error, but was expecting one!")
+// 	}
+//
+// 	if !strings.Contains(err.Error(), "context deadline exceeded") {
+// 		t.Error(err.Error())
+// 	}
+//
+// 	t.Log("Request timed out as expected")
+// }

--- a/get_user_test.go
+++ b/get_user_test.go
@@ -3,6 +3,8 @@ package gowandbox
 import (
 	"context"
 	"testing"
+	"time"
+  "strings"
 )
 
 func TestUserNotFoundError(t *testing.T) {
@@ -18,16 +20,21 @@ func TestUserNotFoundError(t *testing.T) {
 	t.Log("User was not found, as expected")
 }
 
-// func TestUserTimeoutError(t *testing.T) {
-// 	_, err := GetUser("", 1)
-//
-// 	if err == nil {
-// 		t.Error("Got no error, but was expecting one!")
-// 	}
-//
-// 	if !strings.Contains(err.Error(), "context deadline exceeded") {
-// 		t.Error(err.Error())
-// 	}
-//
-// 	t.Log("Request timed out as expected")
-// }
+func TestUserTimeoutError(t *testing.T) {
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+
+	defer cancel()
+
+	_, err := GetUser("", ctx)
+
+	if err == nil {
+		t.Error("Got no error, but was expecting one!")
+	}
+
+	if !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Error(err.Error())
+	}
+
+	t.Log("Request timed out as expected")
+}

--- a/ndjson_execution.go
+++ b/ndjson_execution.go
@@ -11,17 +11,9 @@ import (
 	"net/http"
 )
 
-// Returns new GWBProgram struct, after filling it out with defaults.
-func NewGWBNDProgram() GWBNDProgram {
-	return GWBNDProgram{
-		Compiler:          "",
-		Code:              "",
-		Codes:             []Program{},
-		Options:           "",
-		CompilerOptionRaw: "",
-		RuntimeOptionRaw:  "",
-		Stdin:             "",
-	}
+// Returns new GWBProgram struct
+func NewGWBNDProgram() *GWBNDProgram {
+	return &GWBNDProgram{}
 }
 
 /*

--- a/ndjson_execution_test.go
+++ b/ndjson_execution_test.go
@@ -1,6 +1,7 @@
 package gowandbox
 
 import (
+	"context"
 	"io"
 	"strings"
 	"testing"
@@ -26,7 +27,7 @@ func TestNDExecute(t *testing.T) {
 	prog.Compiler = "cpython-3.8.0"
 	prog.Stdin = "123"
 
-	result, err := prog.Execute(10000)
+	result, err := prog.Execute(context.Background())
 
 	if err != nil {
 		t.Error(err.Error())
@@ -52,32 +53,32 @@ func TestNDExecute(t *testing.T) {
 
 }
 
-func TestNDExecuteTimeout(t *testing.T) {
-	prog := NewGWBNDProgram()
-
-	prog.Code = "import gwbutil\n\ngwbutil.say()"
-	prog.Codes = []Program{
-		{
-			"gwbutil.py",
-			"def say(): print(input())",
-		},
-	}
-	prog.Options = "warning"
-	prog.Compiler = "cpython-3.8.0"
-	prog.Stdin = "123"
-
-	_, err := prog.Execute(1)
-
-	if err == nil {
-		t.Error("Got no error, but was expecting a timeout!")
-	}
-
-	if !strings.Contains(err.Error(), "context deadline exceeded") {
-		t.Error(err.Error())
-	}
-
-	t.Log("Request timed out, as expected")
-}
+// func TestNDExecuteTimeout(t *testing.T) {
+// 	prog := NewGWBNDProgram()
+//
+// 	prog.Code = "import gwbutil\n\ngwbutil.say()"
+// 	prog.Codes = []Program{
+// 		{
+// 			"gwbutil.py",
+// 			"def say(): print(input())",
+// 		},
+// 	}
+// 	prog.Options = "warning"
+// 	prog.Compiler = "cpython-3.8.0"
+// 	prog.Stdin = "123"
+//
+// 	_, err := prog.Execute(1)
+//
+// 	if err == nil {
+// 		t.Error("Got no error, but was expecting a timeout!")
+// 	}
+//
+// 	if !strings.Contains(err.Error(), "context deadline exceeded") {
+// 		t.Error(err.Error())
+// 	}
+//
+// 	t.Log("Request timed out, as expected")
+// }
 
 func TestNDExecuteBadCompilerError(t *testing.T) {
 	prog := NewGWBNDProgram()
@@ -93,7 +94,7 @@ func TestNDExecuteBadCompilerError(t *testing.T) {
 	prog.Compiler = "abc"
 	prog.Stdin = "123"
 
-	_, err := prog.Execute(10000)
+	_, err := prog.Execute(context.Background())
 
 	if err == nil {
 		t.Error("Got no error, but was expecting a server error!")

--- a/ndjson_execution_test.go
+++ b/ndjson_execution_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 )
 
 func assertData(message, want, got string, t *testing.T) {
@@ -53,32 +54,35 @@ func TestNDExecute(t *testing.T) {
 
 }
 
-// func TestNDExecuteTimeout(t *testing.T) {
-// 	prog := NewGWBNDProgram()
-//
-// 	prog.Code = "import gwbutil\n\ngwbutil.say()"
-// 	prog.Codes = []Program{
-// 		{
-// 			"gwbutil.py",
-// 			"def say(): print(input())",
-// 		},
-// 	}
-// 	prog.Options = "warning"
-// 	prog.Compiler = "cpython-3.8.0"
-// 	prog.Stdin = "123"
-//
-// 	_, err := prog.Execute(1)
-//
-// 	if err == nil {
-// 		t.Error("Got no error, but was expecting a timeout!")
-// 	}
-//
-// 	if !strings.Contains(err.Error(), "context deadline exceeded") {
-// 		t.Error(err.Error())
-// 	}
-//
-// 	t.Log("Request timed out, as expected")
-// }
+func TestNDExecuteTimeout(t *testing.T) {
+	prog := NewGWBNDProgram()
+
+	prog.Code = "import gwbutil\n\ngwbutil.say()"
+	prog.Codes = []Program{
+		{
+			"gwbutil.py",
+			"def say(): print(input())",
+		},
+	}
+	prog.Options = "warning"
+	prog.Compiler = "cpython-3.8.0"
+	prog.Stdin = "123"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+
+	_, err := prog.Execute(ctx)
+
+	if err == nil {
+		t.Error("Got no error, but was expecting a timeout!")
+	}
+
+	if !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Error(err.Error())
+	}
+
+	t.Log("Request timed out, as expected")
+}
 
 func TestNDExecuteBadCompilerError(t *testing.T) {
 	prog := NewGWBNDProgram()

--- a/ndjson_execution_test.go
+++ b/ndjson_execution_test.go
@@ -16,7 +16,6 @@ func assertData(message, want, got string, t *testing.T) {
 
 func TestNDExecute(t *testing.T) {
 	prog := NewGWBNDProgram()
-
 	prog.Code = "import gwbutil\n\ngwbutil.say()"
 	prog.Codes = []Program{
 		{

--- a/permlinks.go
+++ b/permlinks.go
@@ -33,6 +33,10 @@ func GetPermLink(link string, ctx context.Context) (GWBPermLink, error) {
 
 	resp, err := client.Do(req)
 
+	if err != nil {
+		return result, err
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		defer resp.Body.Close()
 		e, _ := ioutil.ReadAll(resp.Body)

--- a/permlinks.go
+++ b/permlinks.go
@@ -1,11 +1,11 @@
 package gowandbox
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"time"
 )
 
 /*
@@ -13,21 +13,25 @@ import (
 	Maps to the `/permlink/link` endpoint.
 	If the permlink is not found, and 500 error is returned.
 */
-func GetPermLink(link string, timeout int) (GWBPermLink, error) {
+func GetPermLink(link string, ctx context.Context) (GWBPermLink, error) {
 
 	var result GWBPermLink
 
-	client := http.Client{
-		Timeout: time.Duration(timeout) * time.Millisecond,
-	}
+	client := http.DefaultClient
 
-	resp, err := client.Get(
-		WandBoxUrl + "permlink/" + link,
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+
+		WandBoxUrl+"permlink/"+link,
+		nil,
 	)
 
 	if err != nil {
 		return result, err
 	}
+
+	resp, err := client.Do(req)
 
 	if resp.StatusCode != http.StatusOK {
 		defer resp.Body.Close()

--- a/permlinks_test.go
+++ b/permlinks_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestGetPermLink(t *testing.T) {
@@ -17,19 +18,23 @@ func TestGetPermLink(t *testing.T) {
 	t.Logf("ISO-8601 time - %v", result.Parameter.CreatedAt)
 }
 
-// func TestGetPermLinkTimeoutError(t *testing.T) {
-// 	_, err := GetPermLink("ia8loUVGVV8widMw", 1)
-//
-// 	if err == nil {
-// 		t.Error("Got no error, but was expecting one!")
-// 	}
-//
-// 	if !strings.Contains(err.Error(), "context deadline exceeded") {
-// 		t.Fatal(err.Error())
-// 	}
-//
-// 	t.Log("Request timed out, as expected")
-// }
+func TestGetPermLinkTimeoutError(t *testing.T) {
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+
+	_, err := GetPermLink("ia8loUVGVV8widMw", ctx)
+
+	if err == nil {
+		t.Error("Got no error, but was expecting one!")
+	}
+
+	if !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Fatal(err.Error())
+	}
+
+	t.Log("Request timed out, as expected")
+}
 
 func TestGetPermLinkBadLinkError(t *testing.T) {
 	_, err := GetPermLink("abc", context.Background())

--- a/permlinks_test.go
+++ b/permlinks_test.go
@@ -1,13 +1,14 @@
 package gowandbox
 
 import (
+	"context"
 	"strings"
 	"testing"
 )
 
 func TestGetPermLink(t *testing.T) {
 
-	result, err := GetPermLink("ia8loUVGVV8widMw", 10000)
+	result, err := GetPermLink("ia8loUVGVV8widMw", context.Background())
 
 	if err != nil {
 		t.Error(err.Error())
@@ -16,22 +17,22 @@ func TestGetPermLink(t *testing.T) {
 	t.Logf("ISO-8601 time - %v", result.Parameter.CreatedAt)
 }
 
-func TestGetPermLinkTimeoutError(t *testing.T) {
-	_, err := GetPermLink("ia8loUVGVV8widMw", 1)
-
-	if err == nil {
-		t.Error("Got no error, but was expecting one!")
-	}
-
-	if !strings.Contains(err.Error(), "context deadline exceeded") {
-		t.Fatal(err.Error())
-	}
-
-	t.Log("Request timed out, as expected")
-}
+// func TestGetPermLinkTimeoutError(t *testing.T) {
+// 	_, err := GetPermLink("ia8loUVGVV8widMw", 1)
+//
+// 	if err == nil {
+// 		t.Error("Got no error, but was expecting one!")
+// 	}
+//
+// 	if !strings.Contains(err.Error(), "context deadline exceeded") {
+// 		t.Fatal(err.Error())
+// 	}
+//
+// 	t.Log("Request timed out, as expected")
+// }
 
 func TestGetPermLinkBadLinkError(t *testing.T) {
-	_, err := GetPermLink("abc", 10000)
+	_, err := GetPermLink("abc", context.Background())
 
 	if err == nil {
 		t.Error("Got no error, but was expecting one!")

--- a/types.go
+++ b/types.go
@@ -2,9 +2,10 @@ package gowandbox
 
 import (
 	"bufio"
+	"net/http"
 )
 
-var defaultUrl string = "https://wandbox.org/api/"
+const defaultUrl string = "https://wandbox.org/api/"
 
 // Url to WandBox API
 var WandBoxUrl string = defaultUrl
@@ -48,6 +49,8 @@ type Program struct {
 	program will be saved to WandBox at that url. Default value is false.
 */
 type GWBProgram struct {
+	HttpClient *http.Client
+
 	Compiler string `json:"compiler"`
 
 	Code  string    `json:"code"`


### PR DESCRIPTION
Changed all the http timeouts to better context based requests,  few other minor changes and modified tests.
Note that this change is breaking and will break all functions that used interval as an int. They will now require a context.Context value.